### PR TITLE
update authors and books

### DIFF
--- a/lumenbrary/app/Http/Controllers/AuthorController.php
+++ b/lumenbrary/app/Http/Controllers/AuthorController.php
@@ -24,4 +24,25 @@ class AuthorController extends Controller
     $author = Author::create($request->all());
     return response()->json($author, 201);
   }
+
+  /**
+   * Update the given author.
+   *
+   * @param  Request  $request
+   * @param  string  $id
+   * @return Response
+  */
+  public function update(Request $request, $id)
+  {
+    $author = Author::findOrFail($id);
+
+    $this->validate($request, [
+      'name' => 'required',
+      'email' => 'required|email',
+      'bio' => 'required',
+    ]);
+    $author->update($request->all());
+
+    return response()->json($author, 200);
+  }
 }

--- a/lumenbrary/app/Http/Controllers/BooksController.php
+++ b/lumenbrary/app/Http/Controllers/BooksController.php
@@ -26,4 +26,27 @@ class BooksController extends Controller
     $book = Book::create($request->all());
     return response()->json($book, 201);
   }
+
+  /**
+   * Update the given book.
+   *
+   * @param  Request  $request
+   * @param  string  $id
+   * @return Response
+  */
+  public function update(Request $request, $id)
+  {
+    $book = Book::findOrFail($id);
+
+    $this->validate($request, [
+      'title' => 'required',
+      'description' => 'required',
+      'genre' => 'required',
+      'availability' => 'required',
+      'author_id' => 'required'
+    ]);
+    $book->update($request->all());
+
+    return response()->json($book, 200);
+  }
 }

--- a/lumenbrary/routes/web.php
+++ b/lumenbrary/routes/web.php
@@ -28,9 +28,11 @@ $router->group(['prefix' => 'api/v1'], function() use($router) {
      */
     $router->group(['prefix' => '/books'], function() use($router) {
         $router->post('/', 'BooksController@store');
+        $router->put('/{id}', 'BooksController@update');
     });
 
-    $router->group(['prefix' => '/authors'], function() use(&$router) {
+    $router->group(['prefix' => '/authors'], function() use($router) {
         $router->post('/', 'AuthorController@store');
+        $router->put('/{id}', 'AuthorController@update');
     });
 });


### PR DESCRIPTION
#### What does this PR do?
- enables user update the details of an author or a book, say for example it has been borrowed and not available on the shelf
#### Description of Task to be completed?
- update existing books
- update existing new authors
- ensure they are validated and certain fields are unique to avoid empty fields
#### How should this be manually tested?
- pull in the latest changes, run `php artisan migrate:refresh --seed`
- send a PUT request with the desired field to be edited or changed to http://localhost:8000/api/v1/authors/{id}
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
<img width="1150" alt="Screenshot 2019-06-11 at 12 44 14 PM" src="https://user-images.githubusercontent.com/26186206/59269295-a37d2d80-8c46-11e9-8089-dbcc8b8c9f88.png">
<img width="1150" alt="Screenshot 2019-06-11 at 12 45 00 PM" src="https://user-images.githubusercontent.com/26186206/59269352-bf80cf00-8c46-11e9-80db-d7e0d04ebeef.png">

#### Questions:
N/A