### PR TITLE
get an authors or a books

### DIFF
--- a/lumenbrary/app/Http/Controllers/AuthorController.php
+++ b/lumenbrary/app/Http/Controllers/AuthorController.php
@@ -7,6 +7,20 @@ use Illuminate\Http\Request;
 
 class AuthorController extends Controller
 {
+    /**
+   * Retrieve the auhtor for the given ID.
+   *
+   * @param  int  $id
+   * @return Response
+   */
+  public function show($id)
+  {
+    if(empty(Author::find($id))) {
+      return response()->json(['error' => 'Author does not exist'], 404);
+    }
+    return response()->json(Author::find($id), 200);
+  }
+
   /**
    * Store a new author.
    *

--- a/lumenbrary/app/Http/Controllers/BooksController.php
+++ b/lumenbrary/app/Http/Controllers/BooksController.php
@@ -8,6 +8,20 @@ use Illuminate\Http\Request;
 class BooksController extends Controller
 {
   /**
+   * Retrieve the book for the given ID.
+   *
+   * @param  int  $id
+   * @return Response
+   */
+  public function show($id)
+  {
+    if(!Book::find($id)) {
+      return response()->json(['error' => 'Book does not exist'], 404);
+    }
+    return response()->json(Book::find($id), 200);
+  }
+
+  /**
    * Store a new book.
    *
    * @param  Request  $request

--- a/lumenbrary/routes/web.php
+++ b/lumenbrary/routes/web.php
@@ -22,6 +22,13 @@ $router->group(['prefix' => 'api/v1'], function() use($router) {
     /**
      * Unprotected Routes
      */
+    $router->group(['prefix' => '/books'], function() use($router) {
+        $router->get('/{id}', 'BooksController@show');
+    });
+
+    $router->group(['prefix' => '/authors'], function() use($router) {
+        $router->get('/{id}', 'AuthorController@show');
+    });
 
     /**
      * Protected Routes


### PR DESCRIPTION
#### What does this PR do?
#### Description of Task to be completed?
- show a book
- show an author
- show a descriptive error if book or author does not exist
#### How should this be manually tested?
-  pull in the latest changes, run php artisan migrate:refresh --seed
- send a PUT request with the desired field to be edited or changed to http://localhost:8000/api/v1/authors/{id} and http://localhost:8000/api/v1/books/{id} 
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
<img width="1150" alt="Screenshot 2019-06-11 at 1 58 34 PM" src="https://user-images.githubusercontent.com/26186206/59273986-4470e600-8c51-11e9-8003-cf06858c7b30.png">
<img width="1150" alt="Screenshot 2019-06-11 at 1 59 01 PM" src="https://user-images.githubusercontent.com/26186206/59274008-518dd500-8c51-11e9-9a53-e2e015cea437.png">


#### Questions:
N/A