### PR TITLE
feat(delete an author or a book): allow deleting a single author or book

### DIFF
--- a/lumenbrary/app/Http/Controllers/AuthorController.php
+++ b/lumenbrary/app/Http/Controllers/AuthorController.php
@@ -59,4 +59,20 @@ class AuthorController extends Controller
 
     return response()->json($author, 200);
   }
+
+  /**
+   * Delete an Author
+   *
+   * @param int $id
+   * @return void
+   */
+  public function destroy($id)
+  {
+    if(!Author::find($id)) {
+      return response()->json(['message' => 'Author not found'], 404);
+    }
+
+    Author::findOrFail($id)->delete();
+    return response()->json([], 204);
+  }
 }

--- a/lumenbrary/app/Http/Controllers/BooksController.php
+++ b/lumenbrary/app/Http/Controllers/BooksController.php
@@ -16,7 +16,7 @@ class BooksController extends Controller
   public function show($id)
   {
     if(!Book::find($id)) {
-      return response()->json(['error' => 'Book does not exist'], 404);
+      return response()->json(['message' => 'Book does not exist'], 404);
     }
     return response()->json(Book::find($id), 200);
   }
@@ -62,5 +62,21 @@ class BooksController extends Controller
     $book->update($request->all());
 
     return response()->json($book, 200);
+  }
+
+  /**
+   * Delete a book
+   *
+   * @param int $id
+   * @return void
+   */
+  public function destroy($id)
+  {
+    if(!Book::find($id)) {
+      return response()->json(['message' => 'Book does not exist'], 404);
+    }
+
+    Book::findOrFail($id)->delete();
+    return response()->json(['message' => 'Book has been deleted successfully'], 204);
   }
 }

--- a/lumenbrary/routes/web.php
+++ b/lumenbrary/routes/web.php
@@ -36,10 +36,12 @@ $router->group(['prefix' => 'api/v1'], function() use($router) {
     $router->group(['prefix' => '/books'], function() use($router) {
         $router->post('/', 'BooksController@store');
         $router->put('/{id}', 'BooksController@update');
+        $router->delete('/{id}', 'BooksController@destroy');
     });
 
     $router->group(['prefix' => '/authors'], function() use($router) {
         $router->post('/', 'AuthorController@store');
         $router->put('/{id}', 'AuthorController@update');
+        $router->delete('/{id}', 'AuthorController@destroy');
     });
 });


### PR DESCRIPTION
#### What does this PR do?
- enables user to delete an author and their books or just a book
#### Description of Task to be completed?
- delete a book
- delete an author
- show a descriptive message if book or author does not exist
#### How should this be manually tested?
-  pull in the latest changes, run `php artisan migrate:refresh --seed`
- send a DELETE request with the desired id to be deleted to `http://localhost:8000/api/v1/authors/{id}` or `http://localhost:8000/api/v1/authors/{id}`
*NB* deleting an author also deletes all the books that are related to them.
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A